### PR TITLE
Fixed missing resource owner

### DIFF
--- a/src/SpacesProvider.php
+++ b/src/SpacesProvider.php
@@ -73,9 +73,13 @@ class SpacesProvider extends GenericProvider
 
     protected function createResourceOwner(array $response, AccessToken $token)
     {
+        if (isset($response['profile'])) {
+            $response = array_merge($response['profile'], $response);
+            unset($response['profile']);
+        }
+
         return new SpacesResourceOwner(
             $response,
-            $response["profile"]["id"],
             $this->opts->isSupportLoginAllowed()
         );
     }

--- a/src/SpacesResourceOwner.php
+++ b/src/SpacesResourceOwner.php
@@ -13,20 +13,17 @@ use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 class SpacesResourceOwner implements ResourceOwnerInterface
 {
     private $response;
-    private $resourceOwnerId;
     private $allowSupportLogin;
 
     /**
      * Creates a new SPACES resource owner.
      *
      * @param array  $response          The raw response data
-     * @param string $resourceOwnerId   The resource owner ID
      * @param bool   $allowSupportLogin Allow customer support login
      */
-    public function __construct(array $response, $resourceOwnerId, $allowSupportLogin = true)
+    public function __construct(array $response, $allowSupportLogin = true)
     {
         $this->response = $response;
-        $this->resourceOwnerId = $resourceOwnerId;
         $this->allowSupportLogin = $allowSupportLogin;
     }
 
@@ -47,7 +44,7 @@ class SpacesResourceOwner implements ResourceOwnerInterface
      */
     public function getEmailAddress()
     {
-        return $this->response["profile"]["email"];
+        return $this->response["email"];
     }
 
     /**
@@ -57,8 +54,8 @@ class SpacesResourceOwner implements ResourceOwnerInterface
      */
     public function getFullName()
     {
-        $first = isset($this->response["profile"]["firstName"]) ? $this->response["profile"]["firstName"] : "";
-        $last = isset($this->response["profile"]["lastName"]) ? $this->response["profile"]["lastName"] : "";
+        $first = isset($this->response["firstName"]) ? $this->response["firstName"] : "";
+        $last = isset($this->response["lastName"]) ? $this->response["lastName"] : "";
 
         return trim($first . " " . $last);
     }
@@ -91,7 +88,7 @@ class SpacesResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->resourceOwnerId;
+        return $this->response['id'];
     }
 
     /**

--- a/tests/SpacesResourceOwnerTest.php
+++ b/tests/SpacesResourceOwnerTest.php
@@ -10,13 +10,11 @@ class SpacesResourceOwnerTest extends TestCase
     {
         return new SpacesResourceOwner([
             "role" => $role,
-            "profile" => [
-                "firstName" => "Max",
-                "lastName" => "Mustermann",
-                "email" => "max@mustermann.example",
-                "id" => "85b3b4a0-560e-477a-9f28-badd57fc2d01",
-            ],
-        ], "85b3b4a0-560e-477a-9f28-badd57fc2d01", $allowSupportLogin);
+            "firstName" => "Max",
+            "lastName" => "Mustermann",
+            "email" => "max@mustermann.example",
+            "id" => "85b3b4a0-560e-477a-9f28-badd57fc2d01",
+        ], $allowSupportLogin);
     }
 
     public function testOwnersHaveAdminAccess()
@@ -63,12 +61,10 @@ class SpacesResourceOwnerTest extends TestCase
     {
         $owner = new SpacesResourceOwner([
             "role" => "member",
-            "profile" => [
-                "firstName" => "Max",
-                "email" => "max@mustermann.example",
-                "id" => "85b3b4a0-560e-477a-9f28-badd57fc2d01",
-            ],
-        ], "85b3b4a0-560e-477a-9f28-badd57fc2d01", true);
+            "firstName" => "Max",
+            "email" => "max@mustermann.example",
+            "id" => "85b3b4a0-560e-477a-9f28-badd57fc2d01",
+        ], true);
         assertThat($owner->getFullName(), equalTo("Max"));
     }
 
@@ -76,12 +72,10 @@ class SpacesResourceOwnerTest extends TestCase
     {
         $owner = new SpacesResourceOwner([
             "role" => "member",
-            "profile" => [
-                "lastName" => "Mustermann",
-                "email" => "max@mustermann.example",
-                "id" => "85b3b4a0-560e-477a-9f28-badd57fc2d01",
-            ],
-        ], "85b3b4a0-560e-477a-9f28-badd57fc2d01", true);
+            "lastName" => "Mustermann",
+            "email" => "max@mustermann.example",
+            "id" => "85b3b4a0-560e-477a-9f28-badd57fc2d01",
+        ], true);
         assertThat($owner->getFullName(), equalTo("Mustermann"));
     }
 }


### PR DESCRIPTION
- This PR
- [x] removes and unnecessary class variable
- [x] flats different profile responses
- [x] takes complexity from the resource owner class

i think the breaking change is fine or is there an case i missed - why the owner id was separated given  to the ResourceOwner class?

/cc @martin-helmich 